### PR TITLE
copy-n-pastable_url

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - nosetests "{{ environ["SRC_DIR"] }}"
 
 about:
-  home: https://github.com/{{ gh_org }}/{{ gh_repo }}
+  home: https://github.com/crsmithdev/arrow
   license: Apache-2.0
   summary: Better dates & times for Python
 


### PR DESCRIPTION
@bollwyvl I am not sure how the metadata appears in the Anaconda navigator (@ccordoba12 can probably comment on that), but the `jinja` URL this looks really in some parsers we have around.

PS: The Linux binaries are missing from the channel. See https://circleci.com/gh/conda-forge/arrow-feedstock/8 So merging this should kick of a new build too. (Ping @lukecampbell who pointed that to me.)