### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,17 @@ about:
   home: https://github.com/crsmithdev/arrow
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   summary: 'Better dates & times for Python.'
+  description: |
+    Arrow is a Python library that offers a sensible, human-friendly approach to
+    creating, manipulating, formatting and converting dates, times, and timestamps.
+    It implements and updates the datetime type, plugging gaps in functionality,
+    and provides an intelligent module API that supports many common creation
+    scenarios. Simply put, it helps you work with dates and times with fewer
+    imports and a lot less code.
+  dev_url: https://github.com/crsmithdev/arrow
+  doc_url: http://arrow.readthedocs.org
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.0" %}
+{% set version = "0.12.0" %}
 {% set gh_org = "crsmithdev" %}
 
 package:
@@ -7,11 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arrow/arrow-{{ version }}.tar.gz
-  sha256: 805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722
+  sha256: a15ecfddf334316e3ac8695e48c15d1be0d6038603b33043930dcf0e675c86ee
 
 build:
-  number: 1
-  noarch: python
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -21,6 +20,7 @@ requirements:
   run:
     - python
     - python-dateutil
+    - backports.functools_lru_cache  # [py2k]
 
 test:
   source_files:


### PR DESCRIPTION
noarch has been removed because of py2k selector